### PR TITLE
Add listing CPT plugin with JSON-LD and expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# federated-classifieds
-A wordpress plugin to join the dederated classified hub. A kin of federated Kleinanzeigen or craigslist/
+# Federated Classifieds
+
+A minimal WordPress plugin providing a `listing` custom post type, JSON-LD markup and automatic expiration for federated classified ads.
+
+## Features
+
+- Registers `listing` custom post type.
+- Adds default expiration 60 days after publish and moves listings to an `expired` status via daily cron.
+- Outputs [schema.org](https://schema.org) Offer data as JSON-LD for each listing.
+- Intended to work alongside companion plugins such as [ActivityPub](https://wordpress.org/plugins/activitypub/) and [WebSub](https://wordpress.org/plugins/websub-publisher/).
+
+## Installation
+
+Copy `fed-classifieds.php` to `wp-content/plugins/fed-classifieds/` and activate the plugin in your WordPress admin.
+

--- a/fed-classifieds.php
+++ b/fed-classifieds.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Plugin Name: Fed Classifieds (MVP)
+ * Description: Custom post type "listing" with JSON-LD output and auto-expiration for a federated classifieds network.
+ * Version: 0.1.0
+ * Author: thomi@etik.com + amis
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Register the "listing" custom post type.
+ */
+add_action( 'init', function() {
+    register_post_type( 'listing', [
+        'labels' => [
+            'name'          => __( 'Listings', 'fed-classifieds' ),
+            'singular_name' => __( 'Listing', 'fed-classifieds' ),
+        ],
+        'public'       => true,
+        'has_archive'  => true,
+        'show_in_rest' => true,
+        'supports'     => [ 'title', 'editor', 'thumbnail' ],
+        'rewrite'      => [ 'slug' => 'listings' ],
+    ] );
+} );
+
+/**
+ * Register custom post status "expired".
+ */
+add_action( 'init', function() {
+    register_post_status( 'expired', [
+        'label'                     => _x( 'Expired', 'post', 'fed-classifieds' ),
+        'public'                    => false,
+        'internal'                  => false,
+        'exclude_from_search'       => true,
+        'show_in_admin_all_list'    => true,
+        'show_in_admin_status_list' => true,
+        'label_count'               => _n_noop( 'Expired <span class="count">(%s)</span>', 'Expired <span class="count">(%s)</span>', 'fed-classifieds' ),
+    ] );
+} );
+
+/**
+ * Set default expiration date (60 days) when a listing is saved.
+ */
+add_action( 'save_post_listing', function( $post_id, $post, $update ) {
+    if ( wp_is_post_autosave( $post_id ) || wp_is_post_revision( $post_id ) ) {
+        return;
+    }
+
+    $expires = get_post_meta( $post_id, '_expires_at', true );
+    if ( ! $expires ) {
+        $expires = strtotime( '+60 days', current_time( 'timestamp' ) );
+        update_post_meta( $post_id, '_expires_at', $expires );
+    }
+}, 10, 3 );
+
+/**
+ * Schedule a daily cron event to expire listings.
+ */
+register_activation_hook( __FILE__, function() {
+    if ( ! wp_next_scheduled( 'fed_classifieds_expire_event' ) ) {
+        wp_schedule_event( time(), 'daily', 'fed_classifieds_expire_event' );
+    }
+} );
+
+register_deactivation_hook( __FILE__, function() {
+    wp_clear_scheduled_hook( 'fed_classifieds_expire_event' );
+} );
+
+add_action( 'fed_classifieds_expire_event', function() {
+    $now   = current_time( 'timestamp' );
+    $posts = get_posts( [
+        'post_type'   => 'listing',
+        'post_status' => 'publish',
+        'meta_key'    => '_expires_at',
+        'meta_value'  => $now,
+        'meta_compare'=> '<=',
+        'fields'      => 'ids',
+        'numberposts' => -1,
+    ] );
+
+    foreach ( $posts as $post_id ) {
+        wp_update_post( [ 'ID' => $post_id, 'post_status' => 'expired' ] );
+    }
+} );
+
+/**
+ * Output JSON-LD structured data for listings.
+ */
+add_action( 'wp_head', function() {
+    if ( ! is_singular( 'listing' ) ) {
+        return;
+    }
+
+    $post    = get_queried_object();
+    $price   = get_post_meta( $post->ID, '_price', true );
+    $expires = get_post_meta( $post->ID, '_expires_at', true );
+    $image   = get_the_post_thumbnail_url( $post->ID, 'full' );
+
+    $data = [
+        '@context' => 'https://schema.org/',
+        '@type'    => 'Offer',
+        'name'     => get_the_title( $post ),
+        'description' => wp_strip_all_tags( get_the_excerpt( $post ) ),
+        'url'      => get_permalink( $post ),
+    ];
+
+    if ( $image ) {
+        $data['image'] = $image;
+    }
+    if ( $price ) {
+        $data['price'] = $price;
+    }
+    if ( $expires ) {
+        $data['expires'] = gmdate( 'c', (int) $expires );
+    }
+
+    echo '<script type="application/ld+json">' . wp_json_encode( $data ) . '</script>' . "\n";
+} );
+


### PR DESCRIPTION
## Summary
- add `listing` custom post type with support for title, content and thumbnail
- schedule daily task to move listings to `expired` status after 60 days
- output Offer schema JSON-LD for each listing

## Testing
- `php -l fed-classifieds.php`


------
https://chatgpt.com/codex/tasks/task_e_68badf8d67b8832992e32695ce403b8e