### PR TITLE
Add build script and packaging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,20 @@ A minimal WordPress plugin providing a `listing` custom post type, JSON-LD marku
 - Outputs [schema.org](https://schema.org) Offer data as JSON-LD for each listing.
 - Intended to work alongside companion plugins such as [ActivityPub](https://wordpress.org/plugins/activitypub/) and [WebSub](https://wordpress.org/plugins/websub-publisher/).
 
+## Build
+
+Run the build script to create a distributable plugin archive:
+
+```bash
+./build-zip.sh
+```
+
+This produces `fed-classifieds.zip` containing `fed-classifieds.php` and supporting files.
+
 ## Installation
 
-Copy `fed-classifieds.php` to `wp-content/plugins/fed-classifieds/` and activate the plugin in your WordPress admin.
+1. In your WordPress dashboard, go to **Plugins → Add New → Upload Plugin**.
+2. Choose the generated `fed-classifieds.zip` file and click **Install Now**.
+3. Activate the plugin.
 
+Alternatively, copy `fed-classifieds.php` to `wp-content/plugins/fed-classifieds/` and activate it in your WordPress admin.

--- a/build-zip.sh
+++ b/build-zip.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_DIR="fed-classifieds"
+
+# Clean previous artifacts
+rm -rf "$PLUGIN_DIR" "$PLUGIN_DIR.zip"
+
+mkdir "$PLUGIN_DIR"
+
+cp fed-classifieds.php "$PLUGIN_DIR/"
+if [ -f readme.txt ]; then
+    cp readme.txt "$PLUGIN_DIR/"
+fi
+
+zip -r "${PLUGIN_DIR}.zip" "$PLUGIN_DIR" >/dev/null
+
+# Remove the temporary directory
+rm -rf "$PLUGIN_DIR"
+
+echo "Created ${PLUGIN_DIR}.zip"

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,20 @@
+=== Fed Classifieds ===
+Contributors: thomi, amis
+Requires at least: 5.0
+Tested up to: 6.4
+Stable tag: 0.1.0
+License: GPL-2.0+
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A minimal plugin providing a `listing` custom post type, JSON-LD markup, and automatic expiration for federated classifieds.
+
+== Description ==
+This plugin registers a "listing" custom post type with an expiration date and outputs structured JSON-LD data for each listing.
+
+== Installation ==
+1. Upload the plugin files to the `/wp-content/plugins/fed-classifieds` directory or use the ZIP file with "Upload Plugin".
+2. Activate the plugin through the "Plugins" menu in WordPress.
+
+== Changelog ==
+= 0.1.0 =
+* Initial release.


### PR DESCRIPTION
## Summary
- add build-zip.sh script to assemble plugin archive
- include WordPress-style readme.txt in distribution
- document build and installation process

## Testing
- `./build-zip.sh`
- `unzip -l fed-classifieds.zip`


------
https://chatgpt.com/codex/tasks/task_e_68bae59428e883299c03f3a36e4e6032