### PR TITLE
Add classifieds page template and asset loading

### DIFF
--- a/assets/css/fed-classifieds.css
+++ b/assets/css/fed-classifieds.css
@@ -1,0 +1,3 @@
+.fed-classifieds-listing {
+    margin-bottom: 20px;
+}

--- a/assets/js/fed-classifieds.js
+++ b/assets/js/fed-classifieds.js
@@ -1,0 +1,3 @@
+(function(){
+    console.log('Fed Classifieds assets loaded');
+})();

--- a/templates/listings-page.php
+++ b/templates/listings-page.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Template for the Classifieds listings page.
+ *
+ * @package Fed_Classifieds
+ */
+
+get_header(); ?>
+<div id="primary" class="content-area">
+    <main id="main" class="site-main fed-classifieds-listings">
+        <?php
+        $query = new WP_Query([
+            'post_type'      => 'listing',
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+        ]);
+
+        if ( $query->have_posts() ) :
+            while ( $query->have_posts() ) :
+                $query->the_post();
+                ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class('fed-classifieds-listing'); ?>>
+                    <header class="entry-header">
+                        <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                    </header>
+                    <div class="entry-content">
+                        <?php the_excerpt(); ?>
+                    </div>
+                </article>
+                <?php
+            endwhile;
+            wp_reset_postdata();
+        else :
+            echo '<p>' . esc_html__( 'No listings found.', 'fed-classifieds' ) . '</p>';
+        endif;
+        ?>
+    </main>
+</div>
+
+<?php get_footer();


### PR DESCRIPTION
## Summary
- Create "Classifieds" page on activation and store its ID
- Add listings page template and load it for the created page
- Enqueue CSS/JS assets for the listings view

## Testing
- `php -l fed-classifieds.php`
- `php -l templates/listings-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68bae79fe7d88329b0473f74bdc013de