### PR TITLE
Add ActivityPub inbox and display remote listings

### DIFF
--- a/templates/listings-page.php
+++ b/templates/listings-page.php
@@ -10,7 +10,7 @@ get_header(); ?>
     <main id="main" class="site-main fed-classifieds-listings">
         <?php
         $query = new WP_Query([
-            'post_type'      => 'listing',
+            'post_type'      => [ 'listing', 'ap_object' ],
             'post_status'    => 'publish',
             'posts_per_page' => -1,
         ]);
@@ -21,10 +21,25 @@ get_header(); ?>
                 ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class('fed-classifieds-listing'); ?>>
                     <header class="entry-header">
-                        <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                        <?php if ( 'listing' === get_post_type() ) : ?>
+                            <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                        <?php else : ?>
+                            <h2 class="entry-title"><?php the_title(); ?></h2>
+                        <?php endif; ?>
                     </header>
                     <div class="entry-content">
-                        <?php the_excerpt(); ?>
+                        <?php
+                        if ( 'listing' === get_post_type() ) {
+                            the_excerpt();
+                        } else {
+                            $data = json_decode( get_the_content(), true );
+                            if ( isset( $data['content'] ) ) {
+                                echo wp_kses_post( wpautop( $data['content'] ) );
+                            } elseif ( isset( $data['summary'] ) ) {
+                                echo esc_html( $data['summary'] );
+                            }
+                        }
+                        ?>
                     </div>
                 </article>
                 <?php


### PR DESCRIPTION
## Summary
- add custom post type for ActivityPub objects
- accept ActivityPub inbox POSTs and store them
- show stored ActivityPub objects alongside local listings

## Testing
- `php -l fed-classifieds.php`
- `php -l templates/listings-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68baf1da22888329ac702bf11cb71f3c