### PR TITLE
Add categories and tags to listings

### DIFF
--- a/fed-classifieds.php
+++ b/fed-classifieds.php
@@ -23,6 +23,7 @@ add_action( 'init', function() {
         'has_archive'  => true,
         'show_in_rest' => true,
         'supports'     => [ 'title', 'editor', 'thumbnail' ],
+        'taxonomies'   => [ 'category', 'post_tag' ],
         'rewrite'      => [ 'slug' => 'listings' ],
     ] );
 } );

--- a/templates/listings-page.php
+++ b/templates/listings-page.php
@@ -26,6 +26,18 @@ get_header(); ?>
                     <div class="entry-content">
                         <?php the_excerpt(); ?>
                     </div>
+                    <footer class="entry-footer">
+                        <?php
+                        $categories = get_the_term_list( get_the_ID(), 'category', '<span class="cat-links">', ', ', '</span>' );
+                        if ( $categories ) {
+                            echo $categories; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        }
+                        $tags = get_the_term_list( get_the_ID(), 'post_tag', '<span class="tags-links">', ', ', '</span>' );
+                        if ( $tags ) {
+                            echo $tags; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+                        }
+                        ?>
+                    </footer>
                 </article>
                 <?php
             endwhile;


### PR DESCRIPTION
## Summary
- allow listings to use WordPress categories and tags
- display listing categories and tags on the listings page

## Testing
- `php -l fed-classifieds.php`
- `php -l templates/listings-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68baf1def7cc8329be01d1c5cea04985