### PR TITLE
Add standalone aggregator plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Federated Classifieds
 
-A minimal WordPress plugin providing a `listing` custom post type, JSON-LD markup and automatic expiration for federated classified ads.
+A minimal WordPress plugin providing a `listing` custom post type, JSON-LD markup and automatic expiration for federated classified ads. A companion aggregator plugin is also included for setting up a standalone listings page.
 
 ## Features
 
@@ -11,13 +11,13 @@ A minimal WordPress plugin providing a `listing` custom post type, JSON-LD marku
 
 ## Build
 
-Run the build script to create a distributable plugin archive:
+Run the build script to create distributable plugin archives:
 
 ```bash
 ./build-zip.sh
 ```
 
-This produces `fed-classifieds.zip` containing `fed-classifieds.php` and supporting files.
+This produces `fed-classifieds.zip` containing `fed-classifieds.php` and `fed-classifieds-aggregator.zip` for the standalone aggregator.
 
 ## Installation
 

--- a/build-zip.sh
+++ b/build-zip.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Build main plugin archive
 PLUGIN_DIR="fed-classifieds"
-
-# Clean previous artifacts
 rm -rf "$PLUGIN_DIR" "$PLUGIN_DIR.zip"
-
 mkdir "$PLUGIN_DIR"
-
 cp fed-classifieds.php "$PLUGIN_DIR/"
 if [ -f readme.txt ]; then
     cp readme.txt "$PLUGIN_DIR/"
 fi
-
 zip -r "${PLUGIN_DIR}.zip" "$PLUGIN_DIR" >/dev/null
-
-# Remove the temporary directory
 rm -rf "$PLUGIN_DIR"
-
 echo "Created ${PLUGIN_DIR}.zip"
+
+# Build standalone aggregator archive
+AGG_DIR="fed-classifieds-aggregator"
+rm -rf "$AGG_DIR" "$AGG_DIR.zip"
+mkdir "$AGG_DIR"
+cp fed-classifieds-aggregator.php "$AGG_DIR/"
+cp -r assets templates "$AGG_DIR/"
+zip -r "${AGG_DIR}.zip" "$AGG_DIR" >/dev/null
+rm -rf "$AGG_DIR"
+echo "Created ${AGG_DIR}.zip"

--- a/fed-classifieds-aggregator.php
+++ b/fed-classifieds-aggregator.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Plugin Name: Fed Classifieds Aggregator (MVP)
+ * Description: Standalone aggregator page for federated classifieds.
+ * Version: 0.1.0
+ * Author: thomi@etik.com + amis
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+/**
+ * Register a custom post type for storing incoming ActivityPub objects.
+ */
+add_action( 'init', function() {
+    register_post_type( 'ap_object', [
+        'labels' => [
+            'name'          => __( 'ActivityPub Objects', 'fed-classifieds-aggregator' ),
+            'singular_name' => __( 'ActivityPub Object', 'fed-classifieds-aggregator' ),
+        ],
+        'public'       => false,
+        'show_ui'      => false,
+        'show_in_rest' => false,
+        'supports'     => [ 'title', 'editor' ],
+    ] );
+} );
+
+/**
+ * Handle plugin activation: ensure the Classifieds page exists.
+ */
+function fed_classifieds_aggregator_activate() {
+    $page_id = (int) get_option( 'fed_classifieds_page_id' );
+
+    if ( $page_id && get_post( $page_id ) ) {
+        // Page already exists.
+    } else {
+        $page    = get_page_by_path( 'classifieds' );
+        $page_id = $page ? $page->ID : 0;
+
+        if ( ! $page_id ) {
+            $page_id = wp_insert_post( [
+                'post_title'  => __( 'Classifieds', 'fed-classifieds-aggregator' ),
+                'post_name'   => 'classifieds',
+                'post_status' => 'publish',
+                'post_type'   => 'page',
+            ] );
+        }
+
+        if ( $page_id ) {
+            update_option( 'fed_classifieds_page_id', $page_id );
+        }
+    }
+}
+register_activation_hook( __FILE__, 'fed_classifieds_aggregator_activate' );
+
+/**
+ * Load template for the Classifieds page.
+ */
+add_filter( 'template_include', function( $template ) {
+    $page_id = (int) get_option( 'fed_classifieds_page_id' );
+    if ( $page_id && is_page( $page_id ) ) {
+        $new_template = plugin_dir_path( __FILE__ ) . 'templates/aggregator-page.php';
+        if ( file_exists( $new_template ) ) {
+            return $new_template;
+        }
+    }
+    return $template;
+} );
+
+/**
+ * Enqueue frontend assets for the Classifieds page.
+ */
+add_action( 'wp_enqueue_scripts', function() {
+    $page_id = (int) get_option( 'fed_classifieds_page_id' );
+    if ( $page_id && is_page( $page_id ) ) {
+        wp_enqueue_style( 'fed-classifieds', plugin_dir_url( __FILE__ ) . 'assets/css/fed-classifieds.css', [], '0.1.0' );
+        wp_enqueue_script( 'fed-classifieds', plugin_dir_url( __FILE__ ) . 'assets/js/fed-classifieds.js', [ 'jquery' ], '0.1.0', true );
+    }
+} );
+
+/**
+ * Register ActivityPub inbox endpoint to accept federated objects.
+ */
+add_action( 'rest_api_init', function() {
+    register_rest_route(
+        'fed-classifieds/v1',
+        '/inbox',
+        [
+            'methods'             => WP_REST_Server::CREATABLE,
+            'callback'            => 'fed_classifieds_aggregator_inbox_handler',
+            'permission_callback' => '__return_true',
+        ]
+    );
+} );
+
+/**
+ * Handle incoming ActivityPub objects and store them as "ap_object" posts.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return WP_REST_Response Response.
+ */
+function fed_classifieds_aggregator_inbox_handler( WP_REST_Request $request ) {
+    $object = $request->get_json_params();
+
+    if ( empty( $object ) || ! is_array( $object ) ) {
+        return new WP_REST_Response( [ 'error' => 'Invalid object' ], 400 );
+    }
+
+    $title = '';
+    if ( isset( $object['name'] ) ) {
+        $title = sanitize_text_field( $object['name'] );
+    } elseif ( isset( $object['summary'] ) ) {
+        $title = sanitize_text_field( $object['summary'] );
+    } else {
+        $title = __( 'Remote ActivityPub Object', 'fed-classifieds-aggregator' );
+    }
+
+    $post_id = wp_insert_post(
+        [
+            'post_type'   => 'ap_object',
+            'post_status' => 'publish',
+            'post_title'  => $title,
+            'post_content'=> wp_json_encode( $object ),
+        ],
+        true
+    );
+
+    if ( is_wp_error( $post_id ) ) {
+        return new WP_REST_Response( [ 'error' => 'Could not store object' ], 500 );
+    }
+
+    return new WP_REST_Response( [ 'stored' => $post_id ], 202 );
+}

--- a/templates/aggregator-page.php
+++ b/templates/aggregator-page.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Template for the standalone Classifieds aggregator page.
+ *
+ * @package Fed_Classifieds_Aggregator
+ */
+
+get_header(); ?>
+<div id="primary" class="content-area">
+    <main id="main" class="site-main fed-classifieds-listings">
+        <?php
+        $post_types = [ 'ap_object' ];
+        if ( post_type_exists( 'listing' ) ) {
+            $post_types[] = 'listing';
+        }
+
+        $query = new WP_Query([
+            'post_type'      => $post_types,
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+        ]);
+
+        if ( $query->have_posts() ) :
+            while ( $query->have_posts() ) :
+                $query->the_post();
+                ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class('fed-classifieds-listing'); ?>>
+                    <header class="entry-header">
+                        <?php if ( 'listing' === get_post_type() ) : ?>
+                            <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                        <?php else : ?>
+                            <h2 class="entry-title"><?php the_title(); ?></h2>
+                        <?php endif; ?>
+                    </header>
+                    <div class="entry-content">
+                        <?php
+                        if ( 'listing' === get_post_type() ) {
+                            the_excerpt();
+                        } else {
+                            $data = json_decode( get_the_content(), true );
+                            if ( isset( $data['content'] ) ) {
+                                echo wp_kses_post( wpautop( $data['content'] ) );
+                            } elseif ( isset( $data['summary'] ) ) {
+                                echo esc_html( $data['summary'] );
+                            }
+                        }
+                        ?>
+                    </div>
+                </article>
+                <?php
+            endwhile;
+            wp_reset_postdata();
+        else :
+            echo '<p>' . esc_html__( 'No listings found.', 'fed-classifieds-aggregator' ) . '</p>';
+        endif;
+        ?>
+    </main>
+</div>
+
+<?php get_footer();


### PR DESCRIPTION
## Summary
- add dedicated `fed-classifieds-aggregator.php` plugin that registers an ActivityPub object type and serves a standalone listings page
- include template for aggregator page and package it in build script
- document new aggregator plugin in README

## Testing
- `php -l fed-classifieds-aggregator.php`
- `php -l templates/aggregator-page.php`
- `php -l fed-classifieds.php`
- `./build-zip.sh`


------
https://chatgpt.com/codex/tasks/task_e_68baf2924778832988ab0c658d982adf