### PR TITLE
Flush rewrite rules on plugin activation

### DIFF
--- a/fed-classifieds-aggregator.php
+++ b/fed-classifieds-aggregator.php
@@ -51,6 +51,7 @@ function fed_classifieds_aggregator_activate() {
             update_option( 'fed_classifieds_page_id', $page_id );
         }
     }
+    flush_rewrite_rules();
 }
 register_activation_hook( __FILE__, 'fed_classifieds_aggregator_activate' );
 


### PR DESCRIPTION
## Summary
- Flush rewrite rules when the plugin is activated to ensure permalinks update after creating the Classifieds page

## Testing
- `php -l fed-classifieds-aggregator.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb108793c483298d945a82519cf952