### PR TITLE
Drop external listing post type and handle ActivityPub objects

### DIFF
--- a/fed-classifieds.php
+++ b/fed-classifieds.php
@@ -28,22 +28,6 @@ add_action( 'init', function() {
     ] );
 } );
 
-/**
- * Register the "external_listing" custom post type for remote listings.
- */
-add_action( 'init', function() {
-    register_post_type( 'external_listing', [
-        'labels' => [
-            'name'          => __( 'External Listings', 'fed-classifieds' ),
-            'singular_name' => __( 'External Listing', 'fed-classifieds' ),
-        ],
-        'public'       => true,
-        'has_archive'  => false,
-        'show_in_rest' => true,
-        'supports'     => [ 'title', 'editor', 'thumbnail' ],
-        'rewrite'      => [ 'slug' => 'external-listings' ],
-    ] );
-} );
 
 /**
  * Add "Typ" dropdown to the listing editor.
@@ -100,32 +84,6 @@ add_action( 'init', function() {
     ] );
 } );
 
-/**
- * Add a meta box for external listing URLs and save the value.
- */
-add_action( 'add_meta_boxes', function() {
-    add_meta_box(
-        'external_listing_url',
-        __( 'External URL', 'fed-classifieds' ),
-        function( $post ) {
-            $url = get_post_meta( $post->ID, '_external_url', true );
-            wp_nonce_field( 'external_listing_url_nonce', 'external_listing_url_nonce' );
-            echo '<input type="url" style="width:100%" name="external_listing_url" value="' . esc_attr( $url ) . '" />';
-        },
-        'external_listing'
-    );
-} );
-
-add_action( 'save_post_external_listing', function( $post_id ) {
-    if ( isset( $_POST['external_listing_url_nonce'] ) && wp_verify_nonce( $_POST['external_listing_url_nonce'], 'external_listing_url_nonce' ) ) {
-        $url = isset( $_POST['external_listing_url'] ) ? esc_url_raw( $_POST['external_listing_url'] ) : '';
-        if ( $url ) {
-            update_post_meta( $post_id, '_external_url', $url );
-        } else {
-            delete_post_meta( $post_id, '_external_url' );
-        }
-    }
-} );
 
 /**
  * Save listing type and set default expiration date (60 days).

--- a/templates/listings-page.php
+++ b/templates/listings-page.php
@@ -10,7 +10,7 @@ get_header(); ?>
     <main id="main" class="site-main fed-classifieds-listings">
         <?php
         $query = new WP_Query([
-            'post_type'      => [ 'listing', 'external_listing' ],
+            'post_type'      => [ 'listing', 'ap_object' ],
             'post_status'    => 'publish',
             'posts_per_page' => -1,
         ]);
@@ -18,14 +18,25 @@ get_header(); ?>
         if ( $query->have_posts() ) :
             while ( $query->have_posts() ) :
                 $query->the_post();
-                $link = 'external_listing' === get_post_type() ? get_post_meta( get_the_ID(), '_external_url', true ) : get_permalink();
+                $data = 'ap_object' === get_post_type() ? json_decode( get_the_content(), true ) : [];
                 ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class('fed-classifieds-listing'); ?>>
                     <header class="entry-header">
                         <?php if ( 'listing' === get_post_type() ) : ?>
                             <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-                        <?php else : ?>
-                            <h2 class="entry-title"><a href="<?php echo esc_url( $link ); ?>" target="_blank" rel="nofollow noopener"><?php the_title(); ?></a></h2>
+                        <?php else :
+                            $link = '';
+                            if ( isset( $data['url'] ) ) {
+                                $link = $data['url'];
+                            } elseif ( isset( $data['id'] ) ) {
+                                $link = $data['id'];
+                            }
+                            ?>
+                            <?php if ( $link ) : ?>
+                                <h2 class="entry-title"><a href="<?php echo esc_url( $link ); ?>" target="_blank" rel="nofollow noopener"><?php the_title(); ?></a></h2>
+                            <?php else : ?>
+                                <h2 class="entry-title"><?php the_title(); ?></h2>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </header>
                     <div class="entry-content">
@@ -37,7 +48,6 @@ get_header(); ?>
                             }
                             the_excerpt();
                         } else {
-                            $data = json_decode( get_the_content(), true );
                             if ( isset( $data['content'] ) ) {
                                 echo wp_kses_post( wpautop( $data['content'] ) );
                             } elseif ( isset( $data['summary'] ) ) {


### PR DESCRIPTION
## Summary
- remove external listing post type and related meta box from plugin
- list ActivityPub `ap_object` entries alongside local listings
- link to remote ActivityPub objects when available

## Testing
- `php -l fed-classifieds.php`
- `php -l templates/listings-page.php`
- `php -l templates/aggregator-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb1832de588329be18437e215a7ca1