### PR TITLE
Flush rewrite rules on plugin activation/deactivation

### DIFF
--- a/fed-classifieds.php
+++ b/fed-classifieds.php
@@ -183,12 +183,16 @@ function fed_classifieds_activate() {
     if ( ! wp_next_scheduled( 'fed_classifieds_expire_event' ) ) {
         wp_schedule_event( time(), 'daily', 'fed_classifieds_expire_event' );
     }
+
+    // Flush rewrite rules to ensure custom routes are registered.
+    flush_rewrite_rules();
 }
 
 register_activation_hook( __FILE__, 'fed_classifieds_activate' );
 
 register_deactivation_hook( __FILE__, function() {
     wp_clear_scheduled_hook( 'fed_classifieds_expire_event' );
+    flush_rewrite_rules();
 } );
 
 add_action( 'fed_classifieds_expire_event', function() {


### PR DESCRIPTION
## Summary
- Refresh rewrite rules during plugin activation so new custom routes are recognized immediately
- Flush rewrite rules again on plugin deactivation to clean up

## Testing
- `php -l fed-classifieds.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb1834d3b48329ae347248597c55ee