### PR TITLE
Document REST endpoints and Classifieds page

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A minimal WordPress plugin providing a `listing` custom post type, JSON-LD marku
 - Intended to work alongside companion plugins such as [ActivityPub](https://wordpress.org/plugins/activitypub/) and [WebSub](https://wordpress.org/plugins/websub-publisher/).
 - Provides a `[fed_classifieds_form]` shortcode for frontend submissions that can forward listings to a configurable ActivityPub inbox.
 - On activation some default categories common to classifieds sites are created for convenience.
+- Exposes `/wp-json/fed-classifieds/v1/inbox` (POST) for incoming ActivityPub objects and `/wp-json/fed-classifieds/v1/listings` (GET) to retrieve them together with local listings.
+- Creates a "Classifieds" page on activation and stores its ID in the `fed_classifieds_page_id` option.
 
 ## Build
 
@@ -28,3 +30,9 @@ This produces `fed-classifieds.zip` containing `fed-classifieds.php` and `fed-cl
 3. Activate the plugin.
 
 Alternatively, copy `fed-classifieds.php` to `wp-content/plugins/fed-classifieds/` and activate it in your WordPress admin.
+
+## Classifieds Page and REST API
+
+On activation the plugin creates a **Classifieds** page. Its ID is stored in the `fed_classifieds_page_id` option and can be changed to use an existing page.
+
+The page uses a bundled template that lists local `listing` posts along with any ActivityPub objects that were `POST`ed to `/wp-json/fed-classifieds/v1/inbox`. All listings and received objects are also exposed as an ActivityStreams collection via `GET /wp-json/fed-classifieds/v1/listings`.

--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,15 @@ A minimal plugin providing a `listing` custom post type, JSON-LD markup, automat
 == Description ==
 This plugin registers a "listing" custom post type with an expiration date and outputs structured JSON-LD data for each listing.
 
+On activation a "Classifieds" page is created and its ID stored in the `fed_classifieds_page_id` option. The bundled template displays local listings alongside ActivityPub objects that arrive through the REST inbox.
+
+The plugin provides two REST API endpoints for federation:
+
+* `POST /wp-json/fed-classifieds/v1/inbox` – accepts ActivityPub objects or `Create` activities and stores them as `ap_object` posts.
+* `GET /wp-json/fed-classifieds/v1/listings` – returns an ActivityStreams collection containing local listings and stored objects.
+
+Any objects delivered to the inbox appear on the Classifieds page and in the listings endpoint.
+
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/fed-classifieds` directory or use the ZIP file with "Upload Plugin".
 2. Activate the plugin through the "Plugins" menu in WordPress.


### PR DESCRIPTION
## Summary
- describe `/wp-json/fed-classifieds/v1/inbox` and `/wp-json/fed-classifieds/v1/listings`
- explain automatic creation of the Classifieds page via `fed_classifieds_page_id`
- note how incoming ActivityPub objects appear on the page and in listings

## Testing
- `php -l fed-classifieds.php` *(fails: Unmatched '}' in fed-classifieds.php on line 380)*
- `php -l fed-classifieds-aggregator.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb2c1b03848329a6f11fe0efa4f478