### PR TITLE
Use dedicated taxonomy for listings

### DIFF
--- a/classyfeds-aggregator.php
+++ b/classyfeds-aggregator.php
@@ -24,6 +24,20 @@ add_action( 'init', function() {
         'show_in_rest' => false,
         'supports'     => [ 'title', 'editor' ],
     ] );
+
+    register_taxonomy(
+        'listing_category',
+        [ 'listing', 'ap_object' ],
+        [
+            'labels'       => [
+                'name'          => __( 'Listing Categories', 'classyfeds-aggregator' ),
+                'singular_name' => __( 'Listing Category', 'classyfeds-aggregator' ),
+            ],
+            'public'       => true,
+            'show_in_rest' => true,
+            'hierarchical' => true,
+        ]
+    );
 } );
 
 /**
@@ -264,7 +278,7 @@ function classyfeds_aggregator_listings_handler() {
             }
         }
 
-        $cats = wp_get_post_terms( $post->ID, 'category', [ 'fields' => 'names' ] );
+        $cats = wp_get_post_terms( $post->ID, 'listing_category', [ 'fields' => 'names' ] );
         $items[] = [
             '@context'     => 'https://www.w3.org/ns/activitystreams',
             'id'           => get_permalink( $post ),

--- a/templates/listings-page.php
+++ b/templates/listings-page.php
@@ -58,7 +58,7 @@ get_header(); ?>
                     </div>
                     <footer class="entry-footer">
                         <?php
-                        $categories = get_the_term_list( get_the_ID(), 'category', '<span class="cat-links">', ', ', '</span>' );
+                        $categories = get_the_term_list( get_the_ID(), 'listing_category', '<span class="cat-links">', ', ', '</span>' );
                         if ( $categories ) {
                             echo $categories; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                         }


### PR DESCRIPTION
## Summary
- add `listing_category` taxonomy for listings
- scope default categories and templates to the new taxonomy
- update aggregator to read listing categories

## Testing
- `php -l classyfeds.php`
- `php -l classyfeds-aggregator.php`
- `php -l templates/listings-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb3b98ed80832987b3195c425c525b