### PR TITLE
Fix default submission page shortcode

### DIFF
--- a/classyfeds.php
+++ b/classyfeds.php
@@ -203,7 +203,7 @@ function classyfeds_activate() {
                     'post_name'    => 'submit-listing',
                     'post_status'  => 'publish',
                     'post_type'    => 'page',
-                    'post_content' => '[fed_classifieds_form]',
+                    'post_content' => '[classyfeds_form]',
                 ]
             );
         }


### PR DESCRIPTION
## Summary
- ensure activation generates submission page with [classyfeds_form]

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb40c2d9d88329bd0df949ff7a1534