### PR TITLE
Add shortcode for aggregated listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ On activation the plugin creates a **Classifieds** page. Its ID is stored in the
 The page uses a bundled template that lists local `listing` posts along with any ActivityPub objects that were `POST`ed to `/wp-json/classyfeds/v1/inbox`. All listings and received objects are also exposed as an ActivityStreams collection via `GET /wp-json/classyfeds/v1/listings`.
 =======
 >>>>>>> main
+
+## Shortcode
+
+Use `[classyfeds_listings]` on any page or post to display the aggregated classifieds listings.

--- a/classyfeds-aggregator.php
+++ b/classyfeds-aggregator.php
@@ -180,6 +180,65 @@ add_action( 'wp_enqueue_scripts', function() {
 } );
 
 /**
+ * Render aggregated listings HTML for template and shortcode.
+ *
+ * @return string HTML output.
+ */
+function classyfeds_aggregator_get_listings_html() {
+    $post_types = [ 'ap_object' ];
+    if ( post_type_exists( 'listing' ) ) {
+        $post_types[] = 'listing';
+    }
+
+    $query = new WP_Query(
+        [
+            'post_type'      => $post_types,
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+        ]
+    );
+
+    ob_start();
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class( 'classyfeds-listing' ); ?>>
+                <header class="entry-header">
+                    <?php if ( 'listing' === get_post_type() ) : ?>
+                        <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                    <?php else : ?>
+                        <h2 class="entry-title"><?php the_title(); ?></h2>
+                    <?php endif; ?>
+                </header>
+                <div class="entry-content">
+                    <?php
+                    if ( 'listing' === get_post_type() ) {
+                        the_excerpt();
+                    } else {
+                        $data = json_decode( get_the_content(), true );
+                        if ( isset( $data['content'] ) ) {
+                            echo wp_kses_post( wpautop( $data['content'] ) );
+                        } elseif ( isset( $data['summary'] ) ) {
+                            echo esc_html( $data['summary'] );
+                        }
+                    }
+                    ?>
+                </div>
+            </article>
+            <?php
+        }
+        wp_reset_postdata();
+    } else {
+        echo '<p>' . esc_html__( 'No listings found.', 'classyfeds-aggregator' ) . '</p>';
+    }
+
+    return ob_get_clean();
+}
+
+add_shortcode( 'classyfeds_listings', 'classyfeds_aggregator_get_listings_html' );
+
+/**
  * Register ActivityPub REST endpoints.
  */
 add_action( 'rest_api_init', function() {

--- a/templates/aggregator-page.php
+++ b/templates/aggregator-page.php
@@ -8,52 +8,7 @@
 get_header(); ?>
 <div id="primary" class="content-area">
     <main id="main" class="site-main classyfeds-listings">
-        <?php
-        $post_types = [ 'ap_object' ];
-        if ( post_type_exists( 'listing' ) ) {
-            $post_types[] = 'listing';
-        }
-
-        $query = new WP_Query([
-            'post_type'      => $post_types,
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-        ]);
-
-        if ( $query->have_posts() ) :
-            while ( $query->have_posts() ) :
-                $query->the_post();
-                ?>
-                <article id="post-<?php the_ID(); ?>" <?php post_class('classyfeds-listing'); ?>>
-                    <header class="entry-header">
-                        <?php if ( 'listing' === get_post_type() ) : ?>
-                            <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-                        <?php else : ?>
-                            <h2 class="entry-title"><?php the_title(); ?></h2>
-                        <?php endif; ?>
-                    </header>
-                    <div class="entry-content">
-                        <?php
-                        if ( 'listing' === get_post_type() ) {
-                            the_excerpt();
-                        } else {
-                            $data = json_decode( get_the_content(), true );
-                            if ( isset( $data['content'] ) ) {
-                                echo wp_kses_post( wpautop( $data['content'] ) );
-                            } elseif ( isset( $data['summary'] ) ) {
-                                echo esc_html( $data['summary'] );
-                            }
-                        }
-                        ?>
-                    </div>
-                </article>
-                <?php
-            endwhile;
-            wp_reset_postdata();
-        else :
-            echo '<p>' . esc_html__( 'No listings found.', 'classyfeds-aggregator' ) . '</p>';
-        endif;
-        ?>
+        <?php echo classyfeds_aggregator_get_listings_html(); ?>
     </main>
 </div>
 


### PR DESCRIPTION
## Summary
- introduce `[classyfeds_listings]` shortcode for embedding aggregated classifieds
- reuse listings query for both template and shortcode
- document new shortcode usage

## Testing
- `php -l classyfeds-aggregator.php`
- `php -l templates/aggregator-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb40c832fc8329a73823644614bcb7