### PR TITLE
Style listings grid and prepare dynamic loading

### DIFF
--- a/assets/css/classyfeds.css
+++ b/assets/css/classyfeds.css
@@ -1,3 +1,23 @@
+.classyfeds-listings {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1rem;
+}
+
 .classyfeds-listing {
-    margin-bottom: 20px;
+    background: #fff;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 1rem;
+    box-sizing: border-box;
+}
+
+.classyfeds-listing-image {
+    margin-bottom: 0.5rem;
+}
+
+.classyfeds-listing-image img {
+    width: 100%;
+    height: auto;
+    display: block;
 }

--- a/assets/js/classyfeds.js
+++ b/assets/js/classyfeds.js
@@ -1,3 +1,50 @@
-(function(){
-    console.log('Classyfeds assets loaded');
-})();
+(function ( $ ) {
+    console.log( 'Classyfeds assets loaded' );
+
+    function renderListings( items ) {
+        var $container = $( '.classyfeds-listings' );
+        items.forEach( function ( item ) {
+            var $article = $( '<article/>' ).addClass( 'classyfeds-listing' );
+
+            if ( item.image ) {
+                var $imgWrap = $( '<div/>' ).addClass( 'classyfeds-listing-image' );
+                $( '<img/>' ).attr( 'src', item.image ).attr( 'alt', item.title || '' ).appendTo( $imgWrap );
+                $imgWrap.appendTo( $article );
+            }
+
+            var $header = $( '<header/>' ).addClass( 'entry-header' );
+            $( '<h2/>' ).addClass( 'entry-title' ).text( item.title || '' ).appendTo( $header );
+            $header.appendTo( $article );
+
+            if ( item.content ) {
+                $( '<div/>' ).addClass( 'entry-content' ).html( item.content ).appendTo( $article );
+            }
+
+            $container.append( $article );
+        } );
+    }
+
+    window.classyfedsLoad = function ( endpoint ) {
+        return fetch( endpoint )
+            .then( function ( res ) {
+                return res.json();
+            } )
+            .then( function ( data ) {
+                if ( data && data.orderedItems ) {
+                    var items = data.orderedItems.map( function ( item ) {
+                        var img = '';
+                        if ( item.image ) {
+                            img = item.image.url || item.image;
+                        }
+                        return {
+                            title: item.name || '',
+                            content: item.content || item.summary || '',
+                            image: img,
+                        };
+                    } );
+                    renderListings( items );
+                }
+                return data;
+            } );
+    };
+})( jQuery );

--- a/templates/aggregator-page.php
+++ b/templates/aggregator-page.php
@@ -23,8 +23,21 @@ get_header(); ?>
         if ( $query->have_posts() ) :
             while ( $query->have_posts() ) :
                 $query->the_post();
+                $data = 'ap_object' === get_post_type() ? json_decode( get_the_content(), true ) : [];
                 ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class('classyfeds-listing'); ?>>
+                    <?php if ( 'listing' === get_post_type() && has_post_thumbnail() ) : ?>
+                        <div class="classyfeds-listing-image">
+                            <?php the_post_thumbnail( 'medium' ); ?>
+                        </div>
+                    <?php elseif ( isset( $data['image'] ) ) :
+                        $img = is_array( $data['image'] ) ? ( $data['image']['url'] ?? '' ) : $data['image'];
+                        if ( $img ) : ?>
+                            <div class="classyfeds-listing-image">
+                                <img src="<?php echo esc_url( $img ); ?>" alt="" />
+                            </div>
+                        <?php endif;
+                    endif; ?>
                     <header class="entry-header">
                         <?php if ( 'listing' === get_post_type() ) : ?>
                             <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
@@ -37,7 +50,6 @@ get_header(); ?>
                         if ( 'listing' === get_post_type() ) {
                             the_excerpt();
                         } else {
-                            $data = json_decode( get_the_content(), true );
                             if ( isset( $data['content'] ) ) {
                                 echo wp_kses_post( wpautop( $data['content'] ) );
                             } elseif ( isset( $data['summary'] ) ) {

--- a/templates/listings-page.php
+++ b/templates/listings-page.php
@@ -21,6 +21,18 @@ get_header(); ?>
                 $data = 'ap_object' === get_post_type() ? json_decode( get_the_content(), true ) : [];
                 ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class('classyfeds-listing'); ?>>
+                    <?php if ( 'listing' === get_post_type() && has_post_thumbnail() ) : ?>
+                        <div class="classyfeds-listing-image">
+                            <?php the_post_thumbnail( 'medium' ); ?>
+                        </div>
+                    <?php elseif ( isset( $data['image'] ) ) :
+                        $img = is_array( $data['image'] ) ? ( $data['image']['url'] ?? '' ) : $data['image'];
+                        if ( $img ) : ?>
+                            <div class="classyfeds-listing-image">
+                                <img src="<?php echo esc_url( $img ); ?>" alt="" />
+                            </div>
+                        <?php endif;
+                    endif; ?>
                     <header class="entry-header">
                         <?php if ( 'listing' === get_post_type() ) : ?>
                             <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>


### PR DESCRIPTION
## Summary
- lay out `.classyfeds-listings` as a responsive grid and style individual listing tiles
- include optional listing image markup in templates for `listing` and remote `ap_object`
- add JavaScript helper `classyfedsLoad` to fetch JSON listings and render them dynamically

## Testing
- `php -l templates/aggregator-page.php`
- `php -l templates/listings-page.php`
- `node --check assets/js/classyfeds.js && echo 'JS syntax OK'`


------
https://chatgpt.com/codex/tasks/task_e_68bb40ca40748329a6fe4349a0bf09b6