### PR TITLE
Add admin menu entry for Classifieds Aggregator

### DIFF
--- a/classyfeds-aggregator.php
+++ b/classyfeds-aggregator.php
@@ -70,15 +70,17 @@ function classyfeds_aggregator_activate() {
 register_activation_hook( __FILE__, 'classyfeds_aggregator_activate' );
 
 /**
- * Register settings page in the admin under Settings → Classifieds Aggregator.
+ * Register settings page as top-level admin menu.
  */
 add_action( 'admin_menu', function() {
-    add_options_page(
+    add_menu_page(
         __( 'Classifieds Aggregator', 'classyfeds-aggregator' ),
-        __( 'Classifieds Aggregator', 'classyfeds-aggregator' ),
+        __( 'Classifieds', 'classyfeds-aggregator' ),
         'manage_options',
         'classyfeds-aggregator',
-        'classyfeds_aggregator_settings_page'
+        'classyfeds_aggregator_settings_page',
+        'dashicons-megaphone',
+        25
     );
 } );
 


### PR DESCRIPTION
## Summary
- Replace `add_options_page` with `add_menu_page` so the aggregator appears as a top-level menu item
- Include dashicons-megaphone icon and menu position 25

## Testing
- `php -l classyfeds-aggregator.php`
- `bash build-zip.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bb4167194c8329826f4d4eb73f23c4