### PR TITLE
Fix syntax error in aggregator template

### DIFF
--- a/templates/aggregator-page.php
+++ b/templates/aggregator-page.php
@@ -5,48 +5,57 @@
  * @package Classyfeds_Aggregator
  */
 
-get_header(); ?>
+get_header();
+?>
 <div id="primary" class="content-area">
     <main id="main" class="site-main classyfeds-listings">
         <div class="classyfeds-logo">
             <img src="<?php echo esc_url( plugin_dir_url( dirname( __DIR__ ) ) . 'images/classyfeds.png' ); ?>" alt="ClassyFeds logo" />
         </div>
         <?php
-        $post_types = [ 'ap_object' ];
+        $post_types = array( 'ap_object' );
         if ( post_type_exists( 'listing' ) ) {
             $post_types[] = 'listing';
         }
 
-        $query = new WP_Query([
-            'post_type'      => $post_types,
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-        ]);
+        $query = new WP_Query(
+            array(
+                'post_type'      => $post_types,
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+            )
+        );
 
-        if ( $query->have_posts() ) :
-            while ( $query->have_posts() ) :
+        if ( $query->have_posts() ) {
+            while ( $query->have_posts() ) {
                 $query->the_post();
-                $data = 'ap_object' === get_post_type() ? json_decode( get_the_content(), true ) : [];
+                $data = ( 'ap_object' === get_post_type() ) ? json_decode( get_the_content(), true ) : array();
                 ?>
-                <article id="post-<?php the_ID(); ?>" <?php post_class('classyfeds-listing'); ?>>
-                    <?php if ( 'listing' === get_post_type() && has_post_thumbnail() ) : ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class( 'classyfeds-listing' ); ?>>
+                    <?php
+                    if ( 'listing' === get_post_type() && has_post_thumbnail() ) {
+                        ?>
                         <div class="classyfeds-listing-image">
                             <?php the_post_thumbnail( 'medium' ); ?>
                         </div>
-                    <?php elseif ( isset( $data['image'] ) ) :
+                        <?php
+                    } elseif ( isset( $data['image'] ) ) {
                         $img = is_array( $data['image'] ) ? ( $data['image']['url'] ?? '' ) : $data['image'];
-                        if ( $img ) : ?>
+                        if ( $img ) {
+                            ?>
                             <div class="classyfeds-listing-image">
                                 <img src="<?php echo esc_url( $img ); ?>" alt="" />
                             </div>
-                        <?php endif;
-                    endif; ?>
+                            <?php
+                        }
+                    }
+                    ?>
                     <header class="entry-header">
-                        <?php if ( 'listing' === get_post_type() ) : ?>
+                        <?php if ( 'listing' === get_post_type() ) { ?>
                             <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-                        <?php else : ?>
+                        <?php } else { ?>
                             <h2 class="entry-title"><?php the_title(); ?></h2>
-                        <?php endif; ?>
+                        <?php } ?>
                     </header>
                     <div class="entry-content">
                         <?php
@@ -63,11 +72,11 @@ get_header(); ?>
                     </div>
                 </article>
                 <?php
-            endwhile;
+            }
             wp_reset_postdata();
-        else :
+        } else {
             echo '<p>' . esc_html__( 'No listings found.', 'classyfeds-aggregator' ) . '</p>';
-        endif;
+        }
         ?>
     </main>
 </div>


### PR DESCRIPTION
## Summary
- Rewrite aggregator page template with classic array syntax and braces
- Avoid PHP parse error when loading aggregator page

## Testing
- `php -l templates/aggregator-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb5e9b7a548329be0227d9db32bdfb