### PR TITLE
Add navigation bar for category filtering on aggregator page

### DIFF
--- a/assets/css/classyfeds.css
+++ b/assets/css/classyfeds.css
@@ -1,4 +1,32 @@
+.classyfeds-aggregator {
+    display: flex;
+    gap: 1rem;
+}
+
+.classyfeds-nav {
+    width: 200px;
+}
+
+.classyfeds-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.classyfeds-nav li {
+    margin-bottom: 0.5rem;
+}
+
+.classyfeds-nav a {
+    text-decoration: none;
+}
+
+.classyfeds-nav a.current-cat {
+    font-weight: bold;
+}
+
 .classyfeds-listings {
+    flex: 1;
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 1rem;


### PR DESCRIPTION
## Summary
- Add category navigation sidebar using categories from settings
- Support filtering listings by selected category
- Style aggregator layout with sidebar navigation

## Testing
- `php -l templates/aggregator-page.php`
- `php -l classyfeds-aggregator.php`


------
https://chatgpt.com/codex/tasks/task_e_68be05f069408329b4bf196a9af7d02a