### PR TITLE
Use WordPress helpers in listing form

### DIFF
--- a/assets/css/classyfeds.css
+++ b/assets/css/classyfeds.css
@@ -49,3 +49,45 @@
     height: auto;
     display: block;
 }
+
+/* Form styles */
+.classyfeds-form .wp-block {
+    margin-bottom: 1rem;
+}
+
+.classyfeds-form label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+}
+
+.classyfeds-form input[type="text"],
+.classyfeds-form input[type="number"],
+.classyfeds-form input[type="file"],
+.classyfeds-form select,
+.classyfeds-form textarea {
+    width: 100%;
+    max-width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #7e8993;
+    border-radius: 4px;
+    box-sizing: border-box;
+}
+
+.classyfeds-form .wp-editor-wrap {
+    max-width: 100%;
+}
+
+.classyfeds-form .button-primary {
+    background: #2271b1;
+    border: none;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.classyfeds-form .button-primary:hover {
+    background: #135e96;
+}
+

--- a/classyfeds.php
+++ b/classyfeds.php
@@ -717,35 +717,56 @@ function classyfeds_form_shortcode() {
 
     echo '<form method="post" class="classyfeds-form" enctype="multipart/form-data">';
     wp_nonce_field( 'classyfeds_new_listing', 'classyfeds_nonce' );
-    echo '<p><label for="listing_title">' . esc_html__( 'Title', 'classyfeds' ) . '</label><br />';
-    echo '<input type="text" id="listing_title" name="listing_title" placeholder="' . esc_attr__( 'Short title', 'classyfeds' ) . '" required /></p>';
 
-    echo '<p><label for="listing_content">' . esc_html__( 'Description', 'classyfeds' ) . '</label><br />';
-    echo '<textarea id="listing_content" name="listing_content" rows="5" placeholder="' . esc_attr__( 'Details about the listing', 'classyfeds' ) . '" required></textarea></p>';
+    echo '<div class="wp-block"><label for="listing_title">' . esc_html__( 'Title', 'classyfeds' ) . '</label>';
+    echo '<input type="text" id="listing_title" name="listing_title" class="regular-text" placeholder="' . esc_attr__( 'Short title', 'classyfeds' ) . '" required /></div>';
 
-    echo '<p><label for="listing_type">' . esc_html__( 'Typ', 'classyfeds' ) . '</label><br />';
-    echo '<select id="listing_type" name="listing_type">';
+    echo '<div class="wp-block"><label for="listing_content">' . esc_html__( 'Description', 'classyfeds' ) . '</label>';
+    $editor_settings = [
+        'textarea_name' => 'listing_content',
+        'textarea_rows' => 5,
+        'media_buttons' => false,
+    ];
+    $editor_content = '';
+    ob_start();
+    wp_editor( '', 'listing_content', $editor_settings );
+    $editor_content = ob_get_clean();
+    // Add required attribute to the editor textarea.
+    $editor_content = str_replace( '<textarea', '<textarea required', $editor_content );
+    echo $editor_content;
+    echo '</div>';
+
+    echo '<div class="wp-block"><label for="listing_type">' . esc_html__( 'Typ', 'classyfeds' ) . '</label>';
+    echo '<select id="listing_type" name="listing_type" class="regular-text">';
     echo '<option value="Angebot">' . esc_html__( 'Angebot', 'classyfeds' ) . '</option>';
     echo '<option value="Gesuch">' . esc_html__( 'Gesuch', 'classyfeds' ) . '</option>';
-    echo '</select></p>';
+    echo '</select></div>';
 
-    echo '<p><label for="listing_category">' . esc_html__( 'Category', 'classyfeds' ) . '</label><br />';
-    echo '<select id="listing_category" name="listing_category">';
-    foreach ( $cats as $cat ) {
-        echo '<option value="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</option>';
+    echo '<div class="wp-block"><label for="listing_category">' . esc_html__( 'Category', 'classyfeds' ) . '</label>';
+    $cat_args = [
+        'taxonomy'   => 'listing_category',
+        'hide_empty' => false,
+        'name'       => 'listing_category',
+        'id'         => 'listing_category',
+        'class'      => 'regular-text',
+        'echo'       => 0,
+    ];
+    if ( ! empty( $cats ) ) {
+        $cat_args['include'] = wp_list_pluck( $cats, 'term_id' );
     }
-    echo '</select></p>';
+    echo wp_dropdown_categories( $cat_args );
+    echo '</div>';
 
-    echo '<p><label for="listing_image">' . esc_html__( 'Image', 'classyfeds' ) . '</label><br />';
-    echo '<input type="file" id="listing_image" name="listing_image" accept="image/*" /></p>';
+    echo '<div class="wp-block"><label for="listing_image">' . esc_html__( 'Image', 'classyfeds' ) . '</label>';
+    echo '<input type="file" id="listing_image" name="listing_image" accept="image/*" /></div>';
 
-    echo '<p><label for="listing_price">' . esc_html__( 'Price', 'classyfeds' ) . '</label><br />';
-    echo '<input type="number" id="listing_price" name="listing_price" step="0.01" placeholder="' . esc_attr__( '0.00', 'classyfeds' ) . '" required /></p>';
+    echo '<div class="wp-block"><label for="listing_price">' . esc_html__( 'Price', 'classyfeds' ) . '</label>';
+    echo '<input type="number" id="listing_price" name="listing_price" class="regular-text" step="0.01" placeholder="' . esc_attr__( '0.00', 'classyfeds' ) . '" required /></div>';
 
-    echo '<p><label for="listing_location">' . esc_html__( 'Location', 'classyfeds' ) . '</label><br />';
-    echo '<input type="text" id="listing_location" name="listing_location" required /></p>';
+    echo '<div class="wp-block"><label for="listing_location">' . esc_html__( 'Location', 'classyfeds' ) . '</label>';
+    echo '<input type="text" id="listing_location" name="listing_location" class="regular-text" required /></div>';
 
-    echo '<p><input type="submit" name="classyfeds_submit" value="' . esc_attr__( 'Submit', 'classyfeds' ) . '" /></p>';
+    echo '<div class="wp-block"><input type="submit" name="classyfeds_submit" class="button button-primary" value="' . esc_attr__( 'Submit', 'classyfeds' ) . '" /></div>';
     echo '</form>';
 
     return ob_get_clean();


### PR DESCRIPTION
## Summary
- integrate wp_editor for listing description and add block wrappers
- switch category selection to wp_dropdown_categories and style all fields
- add WordPress-like form styling in classyfeds.css

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68be538bcf948329b1d46fcf3011f27a