### PR TITLE
Add option to hide listings from main post queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A minimal WordPress plugin providing a `listing` custom post type, JSON-LD marku
 - Automatically creates a "Submit Listing" page with the shortcode, including required price and location fields.
 - Exposes `/wp-json/classyfeds/v1/inbox` (POST) for incoming ActivityPub objects and `/wp-json/classyfeds/v1/listings` (GET) to retrieve them together with local listings.
 - Creates a "Classifieds" page on activation and stores its ID in the `classyfeds_page_id` option.
-- Registers a `publish_listings` capability and settings page to choose which roles can submit listings.
+- Registers a `publish_listings` capability and settings page to choose which roles can submit listings and whether listings appear in standard post queries.
 
 ## Capabilities
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: thomi, amis
 Requires at least: 5.0
 Tested up to: 6.4
-Stable tag: 0.1.2
+Stable tag: 0.1.3
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -20,13 +20,16 @@ The plugin provides two REST API endpoints for federation:
 
 Any objects delivered to the inbox appear on the Classifieds page and in the listings endpoint.
 
-The plugin also defines a `publish_listings` capability controlling who may submit listings. An options page under **Settings → Classifieds** lets administrators grant or revoke this capability for roles. By default it is provided to Authors and a new "Listing Contributor" role.
+The plugin also defines a `publish_listings` capability controlling who may submit listings. An options page under **Settings → Classifieds** lets administrators grant or revoke this capability for roles and choose whether listings appear in home, archive, and search queries. By default it is provided to Authors and a new "Listing Contributor" role.
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/classyfeds` directory or use the ZIP file with "Upload Plugin".
 2. Activate the plugin through the "Plugins" menu in WordPress.
 
 == Changelog ==
+= 0.1.3 =
+* Added option to hide listings from home, archive, and search queries.
+
 = 0.1.2 =
 * Added price and location fields to the submission form and created a default "Submit Listing" page.
 * Added `publish_listings` capability and role assignment settings.


### PR DESCRIPTION
## Summary
- add `classyfeds_show_in_posts` setting to control listing visibility
- exclude listings from home, archive, and search queries by default
- document visibility option in settings and readme

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68be53c30948832986c11041f7e47f66