### PR TITLE
Replace listing category meta box and restrict term management

### DIFF
--- a/classyfeds.php
+++ b/classyfeds.php
@@ -25,6 +25,7 @@ add_action( 'init', function() {
         'supports'     => [ 'title', 'editor', 'thumbnail' ],
         'taxonomies'   => [ 'listing_category', 'post_tag' ],
         'rewrite'      => [ 'slug' => 'listings' ],
+        'register_meta_box_cb' => 'classyfeds_register_listing_metaboxes',
     ] );
 
     register_taxonomy(
@@ -39,9 +40,39 @@ add_action( 'init', function() {
             'show_ui'      => true,
             'show_in_rest' => true,
             'hierarchical' => true,
+            'capabilities' => [
+                'manage_terms' => 'manage_listing_categories',
+                'edit_terms'   => 'manage_listing_categories',
+                'delete_terms' => 'manage_listing_categories',
+                'assign_terms' => 'publish_listings',
+            ],
         ]
     );
 } );
+
+/**
+ * Register custom meta boxes for the listing post type.
+ */
+function classyfeds_register_listing_metaboxes() {
+    remove_meta_box( 'listing_categorydiv', 'listing', 'side' );
+
+    add_meta_box(
+        'classyfeds_listing_categorydiv',
+        __( 'Listing Categories', 'classyfeds' ),
+        'classyfeds_listing_category_meta_box',
+        'listing',
+        'side'
+    );
+}
+
+/**
+ * Output the category checklist without term management options.
+ *
+ * @param WP_Post $post The current post object.
+ */
+function classyfeds_listing_category_meta_box( $post ) {
+    wp_terms_checklist( $post->ID, [ 'taxonomy' => 'listing_category' ] );
+}
 
 /**
  * Add "Typ" dropdown to the listing editor.
@@ -239,7 +270,13 @@ function classyfeds_activate() {
         $role = get_role( $role_name );
         if ( $role ) {
             $role->add_cap( 'publish_listings' );
+            $role->remove_cap( 'manage_listing_categories' );
         }
+    }
+
+    $admin = get_role( 'administrator' );
+    if ( $admin ) {
+        $admin->add_cap( 'manage_listing_categories' );
     }
 
     // Flush rewrite rules.
@@ -288,8 +325,10 @@ function classyfeds_settings_page() {
             }
             if ( in_array( $role_key, $selected, true ) ) {
                 $role->add_cap( 'publish_listings' );
+                $role->remove_cap( 'manage_listing_categories' );
             } else {
                 $role->remove_cap( 'publish_listings' );
+                $role->remove_cap( 'manage_listing_categories' );
             }
         }
         $message = __( 'Settings saved.', 'classyfeds' );


### PR DESCRIPTION
## Summary
- Replace default listing_category meta box with custom checklist
- Remove term management capability from listing roles
- Lock taxonomy term management behind manage_listing_categories capability

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68be6f10af3083298da1f858807fed08