### PR TITLE
Remove duplicate form fields in listing form

### DIFF
--- a/classyfeds.php
+++ b/classyfeds.php
@@ -768,16 +768,6 @@ function classyfeds_form_shortcode() {
     echo '<p><input type="submit" name="classyfeds_submit" class="button button-primary" value="' . esc_attr__( 'Submit', 'classyfeds' ) . '" /></p>';
 
 
-    echo '<div class="wp-block"><label for="listing_image">' . esc_html__( 'Image', 'classyfeds' ) . '</label>';
-    echo '<input type="file" id="listing_image" name="listing_image" accept="image/*" /></div>';
-
-    echo '<div class="wp-block"><label for="listing_price">' . esc_html__( 'Price', 'classyfeds' ) . '</label>';
-    echo '<input type="number" id="listing_price" name="listing_price" class="regular-text" step="0.01" placeholder="' . esc_attr__( '0.00', 'classyfeds' ) . '" required /></div>';
-
-    echo '<div class="wp-block"><label for="listing_location">' . esc_html__( 'Location', 'classyfeds' ) . '</label>';
-    echo '<input type="text" id="listing_location" name="listing_location" class="regular-text" required /></div>';
-
-    echo '<div class="wp-block"><input type="submit" name="classyfeds_submit" class="button button-primary" value="' . esc_attr__( 'Submit', 'classyfeds' ) . '" /></div>';
     echo '</form>';
 
     return ob_get_clean();


### PR DESCRIPTION
## Summary
- remove duplicated Image/Price/Location inputs from `classyfeds_form_shortcode`

## Testing
- `php -l classyfeds.php`
- `php test_form.php` (verifies single instance of each input)

------
https://chatgpt.com/codex/tasks/task_e_68be6f4f08708329ad02272f55a70b74