### PR TITLE
Fix aggregator listing links to avoid 404 errors

### DIFF
--- a/assets/js/classyfeds.js
+++ b/assets/js/classyfeds.js
@@ -13,7 +13,18 @@
             }
 
             var $header = $( '<header/>' ).addClass( 'entry-header' );
-            $( '<h2/>' ).addClass( 'entry-title' ).text( item.title || '' ).appendTo( $header );
+            var $title = $( '<h2/>' ).addClass( 'entry-title' );
+            if ( item.link ) {
+                $( '<a/>' )
+                    .attr( 'href', item.link )
+                    .attr( 'target', '_blank' )
+                    .attr( 'rel', 'nofollow noopener' )
+                    .text( item.title || '' )
+                    .appendTo( $title );
+            } else {
+                $title.text( item.title || '' );
+            }
+            $title.appendTo( $header );
             $header.appendTo( $article );
 
             if ( item.content ) {
@@ -36,10 +47,17 @@
                         if ( item.image ) {
                             img = item.image.url || item.image;
                         }
+                        var link = '';
+                        if ( item.url ) {
+                            link = item.url;
+                        } else if ( item.id ) {
+                            link = item.id;
+                        }
                         return {
                             title: item.name || '',
                             content: item.content || item.summary || '',
                             image: img,
+                            link: link,
                         };
                     } );
                     renderListings( items );

--- a/classyfeds-aggregator.php
+++ b/classyfeds-aggregator.php
@@ -230,11 +230,22 @@ function classyfeds_aggregator_get_listings_html() {
     if ( $query->have_posts() ) {
         while ( $query->have_posts() ) {
             $query->the_post();
+            $data = ( 'ap_object' === get_post_type() ) ? json_decode( get_the_content(), true ) : [];
+            $link = '';
+            if ( $data ) {
+                if ( isset( $data['url'] ) ) {
+                    $link = $data['url'];
+                } elseif ( isset( $data['id'] ) ) {
+                    $link = $data['id'];
+                }
+            }
             ?>
             <article id="post-<?php the_ID(); ?>" <?php post_class( 'classyfeds-listing' ); ?>>
                 <header class="entry-header">
                     <?php if ( 'listing' === get_post_type() ) : ?>
                         <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                    <?php elseif ( $link ) : ?>
+                        <h2 class="entry-title"><a href="<?php echo esc_url( $link ); ?>" target="_blank" rel="nofollow noopener"><?php the_title(); ?></a></h2>
                     <?php else : ?>
                         <h2 class="entry-title"><?php the_title(); ?></h2>
                     <?php endif; ?>
@@ -244,7 +255,6 @@ function classyfeds_aggregator_get_listings_html() {
                     if ( 'listing' === get_post_type() ) {
                         the_excerpt();
                     } else {
-                        $data = json_decode( get_the_content(), true );
                         if ( isset( $data['content'] ) ) {
                             echo wp_kses_post( wpautop( $data['content'] ) );
                         } elseif ( isset( $data['summary'] ) ) {

--- a/templates/aggregator-page.php
+++ b/templates/aggregator-page.php
@@ -83,7 +83,19 @@ $current_cat      = isset( $_GET['classyfeds_cat'] ) ? sanitize_title( wp_unslas
                         <?php if ( 'listing' === get_post_type() ) { ?>
                             <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
                         <?php } else { ?>
-                            <h2 class="entry-title"><?php the_title(); ?></h2>
+                            <?php
+                            $link = '';
+                            if ( isset( $data['url'] ) ) {
+                                $link = $data['url'];
+                            } elseif ( isset( $data['id'] ) ) {
+                                $link = $data['id'];
+                            }
+                            ?>
+                            <?php if ( $link ) { ?>
+                                <h2 class="entry-title"><a href="<?php echo esc_url( $link ); ?>" target="_blank" rel="nofollow noopener"><?php the_title(); ?></a></h2>
+                            <?php } else { ?>
+                                <h2 class="entry-title"><?php the_title(); ?></h2>
+                            <?php } ?>
                         <?php } ?>
                     </header>
                     <div class="entry-content">


### PR DESCRIPTION
## Summary
- Link ActivityPub listings to their source URLs in aggregator templates and shortcode
- Handle remote item links in frontend JavaScript rendering

## Testing
- `php -l classyfeds-aggregator.php`
- `php -l templates/aggregator-page.php`
- `node --check assets/js/classyfeds.js && echo "JS syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68be6ef872fc83299a2fe79454f9c6c5