### PR TITLE
Add delivery method field to listings

### DIFF
--- a/classyfeds.php
+++ b/classyfeds.php
@@ -587,9 +587,14 @@ function classyfeds_form_shortcode() {
             $selected_cats = isset( $_POST['listing_category'] ) ? array_filter( array_map( 'absint', (array) wp_unslash( $_POST['listing_category'] ) ) ) : [];
             $price         = isset( $_POST['listing_price'] ) ? sanitize_text_field( wp_unslash( $_POST['listing_price'] ) ) : '';
             $location      = isset( $_POST['listing_location'] ) ? sanitize_text_field( wp_unslash( $_POST['listing_location'] ) ) : '';
+            $delivery      = isset( $_POST['listing_delivery'] ) ? sanitize_text_field( wp_unslash( $_POST['listing_delivery'] ) ) : '';
+            $allowed_deliveries = [ 'Abholung', 'Versand' ];
+            if ( ! in_array( $delivery, $allowed_deliveries, true ) ) {
+                $delivery = '';
+            }
             $image_id      = 0;
 
-            if ( '' === $title || '' === $content || '' === $price || '' === $location || empty( $selected_cats ) ) {
+            if ( '' === $title || '' === $content || '' === $price || '' === $location || '' === $delivery || empty( $selected_cats ) ) {
                 $error = true;
             } else {
                 $post_id = wp_insert_post(
@@ -624,6 +629,7 @@ function classyfeds_form_shortcode() {
 
                     update_post_meta( $post_id, '_price', $price );
                     update_post_meta( $post_id, '_location', $location );
+                    update_post_meta( $post_id, '_delivery_method', $delivery );
 
                     $remote = get_option( 'classyfeds_remote_inbox' );
                     if ( $remote ) {
@@ -639,7 +645,8 @@ function classyfeds_form_shortcode() {
                                 'category'    => array_values( wp_get_post_terms( $post_id, 'listing_category', [ 'fields' => 'names' ] ) ),
                                 'listingType' => $type,
                                 'price'       => $price,
-                                'location'    => $location,
+                                'location'       => $location,
+                                'deliveryMethod' => $delivery,
                             ],
                         ];
                         if ( $image_id ) {
@@ -764,19 +771,14 @@ function classyfeds_form_shortcode() {
     echo '<div class="wp-block"><label for="listing_location">' . esc_html__( 'Location', 'classyfeds' ) . '</label>';
     echo '<input type="text" id="listing_location" name="listing_location" class="regular-text" required /></div>';
 
+    // Delivery method
+    echo '<div class="wp-block"><label for="listing_delivery">' . esc_html__( 'Delivery', 'classyfeds' ) . '</label>';
+    echo '<select id="listing_delivery" name="listing_delivery" class="regular-text" required>';
+    echo '<option value="Abholung">' . esc_html__( 'Abholung', 'classyfeds' ) . '</option>';
+    echo '<option value="Versand">' . esc_html__( 'Versand', 'classyfeds' ) . '</option>';
+    echo '</select></div>';
+
     // Submit
-    echo '<p><input type="submit" name="classyfeds_submit" class="button button-primary" value="' . esc_attr__( 'Submit', 'classyfeds' ) . '" /></p>';
-
-
-    echo '<div class="wp-block"><label for="listing_image">' . esc_html__( 'Image', 'classyfeds' ) . '</label>';
-    echo '<input type="file" id="listing_image" name="listing_image" accept="image/*" /></div>';
-
-    echo '<div class="wp-block"><label for="listing_price">' . esc_html__( 'Price', 'classyfeds' ) . '</label>';
-    echo '<input type="number" id="listing_price" name="listing_price" class="regular-text" step="0.01" placeholder="' . esc_attr__( '0.00', 'classyfeds' ) . '" required /></div>';
-
-    echo '<div class="wp-block"><label for="listing_location">' . esc_html__( 'Location', 'classyfeds' ) . '</label>';
-    echo '<input type="text" id="listing_location" name="listing_location" class="regular-text" required /></div>';
-
     echo '<div class="wp-block"><input type="submit" name="classyfeds_submit" class="button button-primary" value="' . esc_attr__( 'Submit', 'classyfeds' ) . '" /></div>';
     echo '</form>';
 


### PR DESCRIPTION
## Summary
- add delivery method selector to listing form
- validate and save delivery method and include in ActivityPub payload

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68be6f54bc888329a58e1923d5ae2892