### PR TITLE
Use Contact Form 7 for listing submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Classyfeds
 
-A minimal WordPress plugin providing a `listing` custom post type, JSON-LD markup, automatic expiration, and a frontend form that can forward listings to an ActivityPub inbox. On activation it also creates a Classifieds page and a submission page with required price and location fields.
+A minimal WordPress plugin providing a `listing` custom post type, JSON-LD markup, automatic expiration, and a frontend form powered by Contact Form 7 that can forward listings to an ActivityPub inbox. On activation it also creates a Classifieds page and a submission page with required price and shipping fields.
 
 ## Features
 
@@ -8,16 +8,16 @@ A minimal WordPress plugin providing a `listing` custom post type, JSON-LD marku
 - Adds default expiration 60 days after publish and moves listings to an `expired` status via daily cron.
 - Outputs [schema.org](https://schema.org) Offer data as JSON-LD for each listing.
 - Intended to work alongside companion plugins such as [ActivityPub](https://wordpress.org/plugins/activitypub/) and [WebSub](https://wordpress.org/plugins/websub-publisher/).
-- Provides a `[classyfeds_form]` shortcode for frontend submissions that can forward listings to a configurable ActivityPub inbox.
+- Integrates with Contact Form 7 for frontend submissions that can forward listings to a configurable ActivityPub inbox.
 - Creates default categories common to classifieds sites for convenience.
-- Automatically creates a "Submit Listing" page with the shortcode, including required price and location fields.
+- Automatically creates a "Submit Listing" page with the contact form, including required price and shipping fields.
 - Exposes `/wp-json/classyfeds/v1/inbox` (POST) for incoming ActivityPub objects and `/wp-json/classyfeds/v1/listings` (GET) to retrieve them together with local listings.
 - Creates a "Classifieds" page on activation and stores its ID in the `classyfeds_page_id` option.
 - Registers a `publish_listings` capability and settings page to choose which roles can submit listings and whether listings appear in standard post queries.
 
 ## Capabilities
 
-On activation, the plugin creates a `publish_listings` capability and grants it to the built-in Author role as well as a new "Listing Contributor" role. Only users with this capability can submit listings via the `[classyfeds_form]` shortcode. Administrators may assign or revoke this capability for other roles under **Settings → Classifieds**.
+On activation, the plugin creates a `publish_listings` capability and grants it to the built-in Author role as well as a new "Listing Contributor" role. Only users with this capability can submit listings via the submission form. Administrators may assign or revoke this capability for other roles under **Settings → Classifieds**.
 
 ## Build
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,16 +2,16 @@
 Contributors: thomi, amis
 Requires at least: 5.0
 Tested up to: 6.4
-Stable tag: 0.1.3
+Stable tag: 0.1.4
 License: GPL-2.0+
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-A minimal plugin providing a `listing` custom post type, JSON-LD markup, automatic expiration, and a frontend form that can forward listings to an ActivityPub inbox. On activation it also creates a submission page with required price and location fields.
+A minimal plugin providing a `listing` custom post type, JSON-LD markup, automatic expiration, and a frontend form powered by Contact Form 7 that can forward listings to an ActivityPub inbox. On activation it also creates a submission page with required price and shipping fields.
 
 == Description ==
 This plugin registers a "listing" custom post type with an expiration date and outputs structured JSON-LD data for each listing.
 
-On activation a "Classifieds" page is created and its ID stored in the `classyfeds_page_id` option. A separate "Submit Listing" page with the `[classyfeds_form]` shortcode is also generated. The bundled template displays local listings alongside ActivityPub objects that arrive through the REST inbox.
+On activation a "Classifieds" page is created and its ID stored in the `classyfeds_page_id` option. A separate "Submit Listing" page with a Contact Form 7 shortcode is also generated. The bundled template displays local listings alongside ActivityPub objects that arrive through the REST inbox.
 
 The plugin provides two REST API endpoints for federation:
 
@@ -27,6 +27,9 @@ The plugin also defines a `publish_listings` capability controlling who may subm
 2. Activate the plugin through the "Plugins" menu in WordPress.
 
 == Changelog ==
+= 0.1.4 =
+* Replaced `[classyfeds_form]` shortcode with a Contact Form 7 submission form and `wpcf7_mail_sent` handler.
+
 = 0.1.3 =
 * Added option to hide listings from home, archive, and search queries.
 


### PR DESCRIPTION
## Summary
- replace custom `[classyfeds_form]` shortcode with Contact Form 7 form created on activation
- process submissions via `wpcf7_mail_sent` to publish `listing` posts
- store shipping info and update docs to describe Contact Form 7 integration

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68be6f6032e48329b8a930aa395818ec