### PR TITLE
Fix dangling success line and close conditional blocks

### DIFF
--- a/classyfeds.php
+++ b/classyfeds.php
@@ -739,9 +739,11 @@ if ( isset( $_POST['classyfeds_submit'] ) ) {
                     );
                 }
 
-                $success
-
+                $success = true;
+            }
+        }
     }
+}
 
     $submission = WPCF7_Submission::get_instance();
     if ( ! $submission ) {


### PR DESCRIPTION
## Summary
- Complete dangling success flag in classyfeds_cf7_handle_submission
- Close nested conditional blocks to ensure proper structure

## Testing
- `php -l classyfeds.php`


------
https://chatgpt.com/codex/tasks/task_e_68be75985d548329aefcae144a60a893