### PR TITLE
Modularize aggregator with dedicated includes

### DIFF
--- a/classyfeds-aggregator.php
+++ b/classyfeds-aggregator.php
@@ -10,35 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit; // Exit if accessed directly.
 }
 
-/**
- * Register a custom post type for storing incoming ActivityPub objects.
- */
-add_action( 'init', function() {
-    register_post_type( 'ap_object', [
-        'labels' => [
-            'name'          => __( 'ActivityPub Objects', 'classyfeds-aggregator' ),
-            'singular_name' => __( 'ActivityPub Object', 'classyfeds-aggregator' ),
-        ],
-        'public'       => false,
-        'show_ui'      => false,
-        'show_in_rest' => false,
-        'supports'     => [ 'title', 'editor' ],
-    ] );
-
-    register_taxonomy(
-        'listing_category',
-        [ 'listing', 'ap_object' ],
-        [
-            'labels'       => [
-                'name'          => __( 'Listing Categories', 'classyfeds-aggregator' ),
-                'singular_name' => __( 'Listing Category', 'classyfeds-aggregator' ),
-            ],
-            'public'       => true,
-            'show_in_rest' => true,
-            'hierarchical' => true,
-        ]
-    );
-} );
+// Bootstrap components.
+require_once plugin_dir_path( __FILE__ ) . 'includes/ap-object-store.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/activitypub-endpoints.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/render.php';
 
 /**
  * Handle plugin activation: ensure the Classifieds page exists.
@@ -53,12 +28,14 @@ function classyfeds_aggregator_activate() {
         $page_id = $page ? $page->ID : 0;
 
         if ( ! $page_id ) {
-            $page_id = wp_insert_post( [
-                'post_title'  => __( 'Classifieds', 'classyfeds-aggregator' ),
-                'post_name'   => 'classifieds',
-                'post_status' => 'publish',
-                'post_type'   => 'page',
-            ] );
+            $page_id = wp_insert_post(
+                [
+                    'post_title'  => __( 'Classifieds', 'classyfeds-aggregator' ),
+                    'post_name'   => 'classifieds',
+                    'post_status' => 'publish',
+                    'post_type'   => 'page',
+                ]
+            );
         }
 
         if ( $page_id ) {
@@ -92,11 +69,11 @@ function classyfeds_aggregator_settings_page() {
         return;
     }
 
-    $message            = '';
-    $current_page       = (int) get_option( 'classyfeds_page_id' );
-    $remote_inbox       = get_option( 'classyfeds_remote_inbox', '' );
-    $filter_categories  = get_option( 'classyfeds_filter_categories', '' );
-    $filter_posts       = (int) get_option( 'classyfeds_filter_posts', 0 );
+    $message           = '';
+    $current_page      = (int) get_option( 'classyfeds_page_id' );
+    $remote_inbox      = get_option( 'classyfeds_remote_inbox', '' );
+    $filter_categories = get_option( 'classyfeds_filter_categories', '' );
+    $filter_posts      = (int) get_option( 'classyfeds_filter_posts', 0 );
 
     if ( isset( $_POST['classyfeds_save'] ) && check_admin_referer( 'classyfeds_save_settings', 'classyfeds_nonce' ) ) {
         $page_id = isset( $_POST['classyfeds_page_id'] ) ? absint( wp_unslash( $_POST['classyfeds_page_id'] ) ) : 0;
@@ -173,20 +150,6 @@ function classyfeds_aggregator_settings_page() {
 }
 
 /**
- * Load template for the Classifieds page.
- */
-add_filter( 'template_include', function( $template ) {
-    $page_id = (int) get_option( 'classyfeds_page_id' );
-    if ( $page_id && (int) get_queried_object_id() === $page_id ) {
-        $new_template = plugin_dir_path( __FILE__ ) . 'templates/aggregator-page.php';
-        if ( file_exists( $new_template ) ) {
-            return $new_template;
-        }
-    }
-    return $template;
-} );
-
-/**
  * Enqueue frontend assets for the Classifieds page.
  */
 add_action( 'wp_enqueue_scripts', function() {
@@ -206,240 +169,3 @@ add_action( 'wp_enqueue_scripts', function() {
         );
     }
 } );
-
-/**
- * Render aggregated listings HTML for template and shortcode.
- *
- * @return string HTML output.
- */
-function classyfeds_aggregator_get_listings_html() {
-    $post_types = [ 'ap_object' ];
-    if ( post_type_exists( 'listing' ) ) {
-        $post_types[] = 'listing';
-    }
-
-    $query = new WP_Query(
-        [
-            'post_type'      => $post_types,
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-        ]
-    );
-
-    ob_start();
-    if ( $query->have_posts() ) {
-        while ( $query->have_posts() ) {
-            $query->the_post();
-            $data = ( 'ap_object' === get_post_type() ) ? json_decode( get_the_content(), true ) : [];
-            $link = '';
-            if ( $data ) {
-                if ( isset( $data['url'] ) ) {
-                    $link = $data['url'];
-                } elseif ( isset( $data['id'] ) ) {
-                    $link = $data['id'];
-                }
-            }
-            ?>
-            <article id="post-<?php the_ID(); ?>" <?php post_class( 'classyfeds-listing' ); ?>>
-                <header class="entry-header">
-                    <?php if ( 'listing' === get_post_type() ) : ?>
-                        <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
-                    <?php elseif ( $link ) : ?>
-                        <h2 class="entry-title"><a href="<?php echo esc_url( $link ); ?>" target="_blank" rel="nofollow noopener"><?php the_title(); ?></a></h2>
-                    <?php else : ?>
-                        <h2 class="entry-title"><?php the_title(); ?></h2>
-                    <?php endif; ?>
-                </header>
-                <div class="entry-content">
-                    <?php
-                    if ( 'listing' === get_post_type() ) {
-                        the_excerpt();
-                    } else {
-                        if ( isset( $data['content'] ) ) {
-                            echo wp_kses_post( wpautop( $data['content'] ) );
-                        } elseif ( isset( $data['summary'] ) ) {
-                            echo esc_html( $data['summary'] );
-                        }
-                    }
-                    ?>
-                </div>
-            </article>
-            <?php
-        }
-        wp_reset_postdata();
-    } else {
-        echo '<p>' . esc_html__( 'No listings found.', 'classyfeds-aggregator' ) . '</p>';
-    }
-
-    return ob_get_clean();
-}
-
-add_shortcode( 'classyfeds_listings', 'classyfeds_aggregator_get_listings_html' );
-
-/**
- * Register ActivityPub REST endpoints.
- */
-add_action( 'rest_api_init', function() {
-    register_rest_route(
-        'classyfeds/v1',
-        '/inbox',
-        [
-            'methods'             => WP_REST_Server::CREATABLE,
-            'callback'            => 'classyfeds_aggregator_inbox_handler',
-            'permission_callback' => '__return_true',
-        ]
-    );
-
-    register_rest_route(
-        'classyfeds/v1',
-        '/listings',
-        [
-            'methods'             => WP_REST_Server::READABLE,
-            'callback'            => 'classyfeds_aggregator_listings_handler',
-            'permission_callback' => '__return_true',
-        ]
-    );
-} );
-
-/**
- * Handle incoming ActivityPub objects and store them as "ap_object" posts.
- *
- * Supports bare objects as well as "Create" activities.
- *
- * @param WP_REST_Request $request Request object.
- * @return WP_REST_Response Response.
- */
-function classyfeds_aggregator_inbox_handler( WP_REST_Request $request ) {
-    $activity = $request->get_json_params();
-
-    if ( empty( $activity ) || ! is_array( $activity ) ) {
-        return new WP_REST_Response( [ 'error' => 'Invalid object' ], 400 );
-    }
-
-    $object = $activity;
-    if ( isset( $activity['type'] ) && 'Create' === $activity['type'] && ! empty( $activity['object'] ) ) {
-        $object = $activity['object'];
-    }
-
-    $title = '';
-    if ( isset( $object['name'] ) ) {
-        $title = sanitize_text_field( $object['name'] );
-    } elseif ( isset( $object['summary'] ) ) {
-        $title = sanitize_text_field( $object['summary'] );
-    } else {
-        $title = __( 'Remote ActivityPub Object', 'classyfeds-aggregator' );
-    }
-
-    $post_id = wp_insert_post(
-        [
-            'post_type'   => 'ap_object',
-            'post_status' => 'publish',
-            'post_title'  => $title,
-            'post_content'=> wp_json_encode( $object ),
-        ],
-        true
-    );
-
-    if ( is_wp_error( $post_id ) ) {
-        return new WP_REST_Response( [ 'error' => 'Could not store object' ], 500 );
-    }
-
-    return new WP_REST_Response( [ 'stored' => $post_id ], 202 );
-}
-
-/**
- * Expose aggregated listings as an ActivityStreams Collection.
- *
- * @return WP_REST_Response Response.
- */
-function classyfeds_aggregator_listings_handler() {
-    $remote_inbox      = get_option( 'classyfeds_remote_inbox', '' );
-    $filter_categories = get_option( 'classyfeds_filter_categories', '' );
-    $filter_posts      = (int) get_option( 'classyfeds_filter_posts', 0 );
-
-    $args = [
-        'post_type'      => [ 'listing', 'ap_object' ],
-        'post_status'    => 'publish',
-        'posts_per_page' => $filter_posts > 0 ? $filter_posts : -1,
-    ];
-
-    if ( $filter_categories ) {
-        $cats = array_filter( array_map( 'sanitize_title', array_map( 'trim', explode( ',', $filter_categories ) ) ) );
-        if ( $cats ) {
-            $args['tax_query'] = [
-                [
-                    'taxonomy' => 'listing_category',
-                    'field'    => 'slug',
-                    'terms'    => $cats,
-                ],
-            ];
-        }
-    }
-
-    $query = new WP_Query( $args );
-
-    $items = [];
-
-    foreach ( $query->posts as $post ) {
-        if ( 'ap_object' === $post->post_type ) {
-            $data = json_decode( $post->post_content, true );
-            if ( is_array( $data ) ) {
-                if ( empty( $data['@context'] ) ) {
-                    $data['@context'] = 'https://www.w3.org/ns/activitystreams';
-                }
-                $items[] = $data;
-                continue;
-            }
-        }
-
-        $cats = wp_get_post_terms( $post->ID, 'listing_category', [ 'fields' => 'names' ] );
-        $items[] = [
-            '@context'     => 'https://www.w3.org/ns/activitystreams',
-            'id'           => get_permalink( $post ),
-            'type'         => 'Note',
-            'name'         => get_the_title( $post ),
-            'content'      => apply_filters( 'the_content', $post->post_content ),
-            'url'          => get_permalink( $post ),
-            'published'    => mysql2date( 'c', $post->post_date_gmt, false ),
-            'attributedTo' => home_url(),
-            'category'     => $cats,
-            'listingType'  => get_post_meta( $post->ID, '_listing_type', true ),
-        ];
-    }
-
-    if ( $remote_inbox ) {
-        $response = wp_remote_get( $remote_inbox );
-        if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
-            $body = wp_remote_retrieve_body( $response );
-            $data = json_decode( $body, true );
-            if ( isset( $data['orderedItems'] ) && is_array( $data['orderedItems'] ) ) {
-                foreach ( $data['orderedItems'] as $item ) {
-                    if ( ! empty( $cats ) ) {
-                        $item_cats = [];
-                        if ( isset( $item['category'] ) ) {
-                            $item_cats = (array) $item['category'];
-                        }
-                        if ( ! array_intersect( $cats, $item_cats ) ) {
-                            continue;
-                        }
-                    }
-                    $items[] = $item;
-                }
-            }
-        }
-    }
-
-    if ( $filter_posts > 0 ) {
-        $items = array_slice( $items, 0, $filter_posts );
-    }
-
-    $collection = [
-        '@context'     => 'https://www.w3.org/ns/activitystreams',
-        'id'           => rest_url( 'classyfeds/v1/listings' ),
-        'type'         => 'OrderedCollection',
-        'totalItems'   => count( $items ),
-        'orderedItems' => $items,
-    ];
-
-    return new WP_REST_Response( $collection );
-}

--- a/includes/activitypub-endpoints.php
+++ b/includes/activitypub-endpoints.php
@@ -1,0 +1,202 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Verify HTTP signature of an ActivityPub request.
+ *
+ * @param WP_REST_Request $request Request object.
+ * @return bool True on valid signature or if none provided.
+ */
+function classyfeds_aggregator_verify_signature( WP_REST_Request $request ) {
+    $signature = $request->get_header( 'signature' );
+    if ( empty( $signature ) ) {
+        return true;
+    }
+
+    $sig_params = [];
+    foreach ( explode( ',', $signature ) as $part ) {
+        if ( strpos( $part, '=' ) !== false ) {
+            list( $k, $v ) = array_map( 'trim', explode( '=', $part, 2 ) );
+            $sig_params[ strtolower( $k ) ] = trim( $v, '"' );
+        }
+    }
+
+    if ( empty( $sig_params['keyid'] ) || empty( $sig_params['signature'] ) ) {
+        return false;
+    }
+
+    $key_res = wp_remote_get( $sig_params['keyid'] );
+    if ( 200 !== wp_remote_retrieve_response_code( $key_res ) ) {
+        return false;
+    }
+
+    $body = wp_remote_retrieve_body( $key_res );
+    $data = json_decode( $body, true );
+    if ( empty( $data['publicKey']['publicKeyPem'] ) ) {
+        return false;
+    }
+
+    $headers        = array_change_key_case( $request->get_headers(), CASE_LOWER );
+    $signed_headers = explode( ' ', $sig_params['headers'] ?? '(request-target)' );
+
+    $signing_string = '';
+    foreach ( $signed_headers as $header ) {
+        $header = trim( $header );
+        if ( '(request-target)' === $header ) {
+            $signing_string .= '(request-target): ' . strtolower( $request->get_method() ) . ' ' . $request->get_route() . "\n";
+        } elseif ( isset( $headers[ $header ] ) ) {
+            $signing_string .= $header . ': ' . implode( ', ', $headers[ $header ] ) . "\n";
+        }
+    }
+    $signing_string = rtrim( $signing_string, "\n" );
+
+    $pubkey = openssl_pkey_get_public( $data['publicKey']['publicKeyPem'] );
+    if ( ! $pubkey ) {
+        return false;
+    }
+
+    $verified = openssl_verify( $signing_string, base64_decode( $sig_params['signature'] ), $pubkey, OPENSSL_ALGO_SHA256 );
+    openssl_free_key( $pubkey );
+
+    return 1 === $verified;
+}
+
+add_action( 'rest_api_init', function() {
+    register_rest_route(
+        'classyfeds/v1',
+        '/inbox',
+        [
+            'methods'             => WP_REST_Server::CREATABLE,
+            'callback'            => 'classyfeds_aggregator_inbox_handler',
+            'permission_callback' => '__return_true',
+        ]
+    );
+
+    register_rest_route(
+        'classyfeds/v1',
+        '/listings',
+        [
+            'methods'             => WP_REST_Server::READABLE,
+            'callback'            => 'classyfeds_aggregator_listings_handler',
+            'permission_callback' => '__return_true',
+        ]
+    );
+} );
+
+function classyfeds_aggregator_inbox_handler( WP_REST_Request $request ) {
+    if ( ! classyfeds_aggregator_verify_signature( $request ) ) {
+        return new WP_REST_Response( [ 'error' => 'Invalid signature' ], 401 );
+    }
+
+    $activity = $request->get_json_params();
+
+    if ( empty( $activity ) || ! is_array( $activity ) ) {
+        return new WP_REST_Response( [ 'error' => 'Invalid object' ], 400 );
+    }
+
+    $object = $activity;
+    if ( isset( $activity['type'] ) && 'Create' === $activity['type'] && ! empty( $activity['object'] ) ) {
+        $object = $activity['object'];
+    }
+
+    $post_id = classyfeds_aggregator_store_ap_object( $object );
+    if ( is_wp_error( $post_id ) ) {
+        return new WP_REST_Response( [ 'error' => 'Could not store object' ], 500 );
+    }
+
+    return new WP_REST_Response( [ 'stored' => $post_id ], 202 );
+}
+
+function classyfeds_aggregator_listings_handler( WP_REST_Request $request ) {
+    $remote_inbox      = get_option( 'classyfeds_remote_inbox', '' );
+    $filter_categories = get_option( 'classyfeds_filter_categories', '' );
+    $filter_posts      = (int) get_option( 'classyfeds_filter_posts', 0 );
+
+    $args = [
+        'post_type'      => [ 'listing', 'ap_object' ],
+        'post_status'    => 'publish',
+        'posts_per_page' => $filter_posts > 0 ? $filter_posts : -1,
+    ];
+
+    $filter_cat_slugs = [];
+    if ( $filter_categories ) {
+        $filter_cat_slugs = array_filter( array_map( 'sanitize_title', array_map( 'trim', explode( ',', $filter_categories ) ) ) );
+        if ( $filter_cat_slugs ) {
+            $args['tax_query'] = [
+                [
+                    'taxonomy' => 'listing_category',
+                    'field'    => 'slug',
+                    'terms'    => $filter_cat_slugs,
+                ],
+            ];
+        }
+    }
+
+    $query = new WP_Query( $args );
+    $items = [];
+
+    foreach ( $query->posts as $post ) {
+        if ( 'ap_object' === $post->post_type ) {
+            $data = json_decode( $post->post_content, true );
+            if ( is_array( $data ) ) {
+                if ( empty( $data['@context'] ) ) {
+                    $data['@context'] = 'https://www.w3.org/ns/activitystreams';
+                }
+                $items[] = $data;
+                continue;
+            }
+        }
+
+        $post_cats = wp_get_post_terms( $post->ID, 'listing_category', [ 'fields' => 'names' ] );
+        $items[]   = [
+            '@context'     => 'https://www.w3.org/ns/activitystreams',
+            'id'           => get_permalink( $post ),
+            'type'         => 'Note',
+            'name'         => get_the_title( $post ),
+            'content'      => apply_filters( 'the_content', $post->post_content ),
+            'url'          => get_permalink( $post ),
+            'published'    => mysql2date( 'c', $post->post_date_gmt, false ),
+            'attributedTo' => home_url(),
+            'category'     => $post_cats,
+            'listingType'  => get_post_meta( $post->ID, '_listing_type', true ),
+        ];
+    }
+
+    if ( $remote_inbox ) {
+        $response = wp_remote_get( $remote_inbox );
+        if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+            $body = wp_remote_retrieve_body( $response );
+            $data = json_decode( $body, true );
+            if ( isset( $data['orderedItems'] ) && is_array( $data['orderedItems'] ) ) {
+                foreach ( $data['orderedItems'] as $item ) {
+                    if ( $filter_cat_slugs ) {
+                        $item_cats = [];
+                        if ( isset( $item['category'] ) ) {
+                            $item_cats = (array) $item['category'];
+                        }
+                        if ( ! array_intersect( $filter_cat_slugs, $item_cats ) ) {
+                            continue;
+                        }
+                    }
+                    $items[] = $item;
+                }
+            }
+        }
+    }
+
+    if ( $filter_posts > 0 ) {
+        $items = array_slice( $items, 0, $filter_posts );
+    }
+
+    $collection = [
+        '@context'     => 'https://www.w3.org/ns/activitystreams',
+        'id'           => rest_url( 'classyfeds/v1/listings' ),
+        'type'         => 'OrderedCollection',
+        'totalItems'   => count( $items ),
+        'orderedItems' => $items,
+    ];
+
+    return new WP_REST_Response( $collection );
+}

--- a/includes/ap-object-store.php
+++ b/includes/ap-object-store.php
@@ -1,0 +1,58 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_action( 'init', function() {
+    register_post_type( 'ap_object', [
+        'labels' => [
+            'name'          => __( 'ActivityPub Objects', 'classyfeds-aggregator' ),
+            'singular_name' => __( 'ActivityPub Object', 'classyfeds-aggregator' ),
+        ],
+        'public'       => false,
+        'show_ui'      => false,
+        'show_in_rest' => false,
+        'supports'     => [ 'title', 'editor' ],
+    ] );
+
+    register_taxonomy(
+        'listing_category',
+        [ 'listing', 'ap_object' ],
+        [
+            'labels'       => [
+                'name'          => __( 'Listing Categories', 'classyfeds-aggregator' ),
+                'singular_name' => __( 'Listing Category', 'classyfeds-aggregator' ),
+            ],
+            'public'       => true,
+            'show_in_rest' => true,
+            'hierarchical' => true,
+        ]
+    );
+} );
+
+/**
+ * Store an ActivityPub object as an `ap_object` post.
+ *
+ * @param array $object ActivityPub object.
+ * @return int|WP_Error Post ID on success or error.
+ */
+function classyfeds_aggregator_store_ap_object( array $object ) {
+    $title = '';
+    if ( isset( $object['name'] ) ) {
+        $title = sanitize_text_field( $object['name'] );
+    } elseif ( isset( $object['summary'] ) ) {
+        $title = sanitize_text_field( $object['summary'] );
+    } else {
+        $title = __( 'Remote ActivityPub Object', 'classyfeds-aggregator' );
+    }
+
+    return wp_insert_post(
+        [
+            'post_type'   => 'ap_object',
+            'post_status' => 'publish',
+            'post_title'  => $title,
+            'post_content'=> wp_json_encode( $object ),
+        ],
+        true
+    );
+}

--- a/includes/render.php
+++ b/includes/render.php
@@ -1,0 +1,84 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+add_filter( 'template_include', function( $template ) {
+    $page_id = (int) get_option( 'classyfeds_page_id' );
+    if ( $page_id && (int) get_queried_object_id() === $page_id ) {
+        $new_template = plugin_dir_path( __FILE__ ) . '../templates/aggregator-page.php';
+        if ( file_exists( $new_template ) ) {
+            return $new_template;
+        }
+    }
+    return $template;
+} );
+
+/**
+ * Render aggregated listings HTML for template and shortcode.
+ *
+ * @return string HTML output.
+ */
+function classyfeds_aggregator_get_listings_html() {
+    $post_types = [ 'ap_object' ];
+    if ( post_type_exists( 'listing' ) ) {
+        $post_types[] = 'listing';
+    }
+
+    $query = new WP_Query(
+        [
+            'post_type'      => $post_types,
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+        ]
+    );
+
+    ob_start();
+    if ( $query->have_posts() ) {
+        while ( $query->have_posts() ) {
+            $query->the_post();
+            $data = ( 'ap_object' === get_post_type() ) ? json_decode( get_the_content(), true ) : [];
+            $link = '';
+            if ( $data ) {
+                if ( isset( $data['url'] ) ) {
+                    $link = $data['url'];
+                } elseif ( isset( $data['id'] ) ) {
+                    $link = $data['id'];
+                }
+            }
+            ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class( 'classyfeds-listing' ); ?>>
+                <header class="entry-header">
+                    <?php if ( 'listing' === get_post_type() ) : ?>
+                        <h2 class="entry-title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h2>
+                    <?php elseif ( $link ) : ?>
+                        <h2 class="entry-title"><a href="<?php echo esc_url( $link ); ?>" target="_blank" rel="nofollow noopener"><?php the_title(); ?></a></h2>
+                    <?php else : ?>
+                        <h2 class="entry-title"><?php the_title(); ?></h2>
+                    <?php endif; ?>
+                </header>
+                <div class="entry-content">
+                    <?php
+                    if ( 'listing' === get_post_type() ) {
+                        the_excerpt();
+                    } else {
+                        if ( isset( $data['content'] ) ) {
+                            echo wp_kses_post( wpautop( $data['content'] ) );
+                        } elseif ( isset( $data['summary'] ) ) {
+                            echo esc_html( $data['summary'] );
+                        }
+                    }
+                    ?>
+                </div>
+            </article>
+            <?php
+        }
+        wp_reset_postdata();
+    } else {
+        echo '<p>' . esc_html__( 'No listings found.', 'classyfeds-aggregator' ) . '</p>';
+    }
+
+    return ob_get_clean();
+}
+
+add_shortcode( 'classyfeds_listings', 'classyfeds_aggregator_get_listings_html' );


### PR DESCRIPTION
## Summary
- Factor ActivityPub object post-type registration and storage into `includes/ap-object-store.php`
- Add `includes/activitypub-endpoints.php` providing signature verification and inbox/outbox REST handlers
- Keep template routing and listings rendering in `includes/render.php`, bootstrapped by the main plugin

## Testing
- `php -l classyfeds-aggregator.php`
- `php -l includes/ap-object-store.php`
- `php -l includes/activitypub-endpoints.php`
- `php -l includes/render.php`


------
https://chatgpt.com/codex/tasks/task_e_68c19e47e45483299a4cda5301430a6d